### PR TITLE
feat: k8s.adopt

### DIFF
--- a/examples/adopt.jsonnet
+++ b/examples/adopt.jsonnet
@@ -1,0 +1,55 @@
+(import '../k8s.libsonnet').RootComponent {
+  k8s+: {
+    ObjectMeta: {
+      namespace: 'myns',
+    },
+  },
+
+  upstream: $.k8s.adopt(std.parseYaml(importstr 'adopt.yaml')),
+}
+
+/*
+You can compare the rendered version of this file with the `adopt.yaml` "upstream" version:
+
+```bash
+diff -u examples/adopt.yaml <(kubecfg show examples/adopt.jsonnet)
+```
+
+
+```diff
+--- examples/adopt.yaml	2023-11-29 14:56:10.368934322 +0100
++++ /dev/fd/11	2023-11-29 17:28:39.665967467 +0100
+@@ -5,11 +5,13 @@
+ kind: ConfigMap
+ metadata:
+   name: foo
++  namespace: myns
+ ---
+ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx
++  namespace: myns
+ spec:
+   replicas: 2
+   selector:
+@@ -17,6 +19,8 @@
+       app: nginx
+   template:
+     metadata:
++      annotations:
++        kubectl.kubernetes.io/default-container: nginx
+       labels:
+         app: nginx
+     spec:
+@@ -40,6 +44,7 @@
+ kind: Service
+ metadata:
+   name: nginx
++  namespace: myns
+ spec:
+   ports:
+   - name: http
+```
+
+*/

--- a/examples/adopt.yaml
+++ b/examples/adopt.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+data:
+  bar: baz
+kind: ConfigMap
+metadata:
+  name: foo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - env:
+        - name: BAR
+          valueFrom:
+            configMapKeyRef:
+              key: bar
+              name: foo
+        image: nginx:1.14.2
+        name: nginx
+        ports:
+        - containerPort: 80
+          name: http
+        volumeMounts: []
+      initContainers: []
+      volumes: []
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app: nginx


### PR DESCRIPTION
Not all k8s resources one end up using in a k8s clusters are hand crafted by the user.

Often times it happens that one needs to import k8s resources written by somebody else.
Or it's also possible that the best way to define a k8s resource is not to craft it in jsonnet.

Next step: handle `containers_` and `env_` vars etc...
